### PR TITLE
feat: --copy-files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ There are options that can be passed to provide custom output locations, file ex
 You can run `babel-dual-package --help` to get more info. Below is the output of that:
 
 ```console
+user@comp ~ $ ./node_modules/.bin/babel-dual-package --help
 Usage: babel-dual-package [options] <files ...>
 
 Options:
@@ -164,6 +165,7 @@ Options:
 --no-cjs-dir 			 Do not create a subdirectory for the CJS build in --out-dir.
 --source-maps 			 Generate an external source map.
 --minified  			 Save as many bytes when printing (false by default).
+--copy-files 			 When compiling a directory copy over non-compilable files.
 --help 				 Output usage information (this information).
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babel-dual-package",
-      "version": "1.0.0-rc.3",
+      "version": "1.0.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "description": "CLI for building a dual ESM and CJS package with Babel.",
   "type": "module",
   "main": "dist",

--- a/src/init.js
+++ b/src/init.js
@@ -86,6 +86,10 @@ const init = async (moduleArgs, onError = () => {}) => {
         minified: {
           type: 'boolean',
           default: false
+        },
+        'copy-files': {
+          type: 'boolean',
+          default: false
         }
       }
     })
@@ -154,6 +158,9 @@ const init = async (moduleArgs, onError = () => {}) => {
     )
     logHelp('--source-maps \t\t\t Generate an external source map.')
     logHelp('--minified  \t\t\t Save as many bytes when printing (false by default).')
+    logHelp(
+      '--copy-files \t\t\t When compiling a directory copy over non-compilable files.'
+    )
     logHelp(`--help \t\t\t\t Output usage information (this information).`)
   }
 

--- a/test/__fixtures__/copy/dir/file.json
+++ b/test/__fixtures__/copy/dir/file.json
@@ -1,0 +1,4 @@
+{
+  "some": "json",
+  "isBoolean": true
+}

--- a/test/__fixtures__/copy/file.html
+++ b/test/__fixtures__/copy/file.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>tts-react UMD example</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://unpkg.com/tts-react@3.0.1/dist/umd/tts-react.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const root = ReactDOM.createRoot(document.getElementById('root'))
+      const { TextToSpeech, useTts } = TTSReact
+      const CustomTTS = ({ children }) => {
+        const { play, ttsChildren } = useTts({ children })
+
+        return (
+          <>
+            <button onClick={() => play()}>Play</button>
+            <div>{ttsChildren}</div>
+          </>
+        )
+      }
+
+      root.render(
+        <>
+          <CustomTTS>
+            <p><code>useTts</code> as a UMD module.</p>
+          </CustomTTS>
+          <TextToSpeech markTextAsSpoken>
+            <p><code>TextToSpeech</code> as a UMD module.</p>
+          </TextToSpeech>
+        </>
+      )
+    </script>
+  </body>
+</html>

--- a/test/__fixtures__/copy/file.js
+++ b/test/__fixtures__/copy/file.js
@@ -1,0 +1,15 @@
+import { mod } from 'specifier'
+
+import foo from './bar.js'
+
+import(`./${dynamicMod}.js`)
+
+import { mjs } from './module.mjs'
+
+import { cjs } from './module.cjs'
+
+import json from './file.json'
+
+import(new String('./relative' + new String('module.js')))
+
+export const js = 'rocks'

--- a/test/index.js
+++ b/test/index.js
@@ -238,4 +238,40 @@ describe('babel-dual-package', () => {
     // Check that any unnecessary .d.ts files are removed if using extended extensions
     assert.ok(!existsSync(resolve(dist, 'file.d.ts')))
   })
+
+  it('copies declaration files as-is when using --keep-file-extension', async (t) => {
+    const { babelDualPackage } = await import('../src/index.js')
+    const spy = t.mock.method(global.console, 'log')
+
+    await mkdir(dist, { recursive: true })
+    await cp(resolve(fixtures, 'types', 'file.d.ts'), resolve(dist, 'file.d.ts'), {
+      recursive: true
+    })
+    await babelDualPackage([
+      'test/__fixtures__/ts/file.d.ts',
+      '--extensions',
+      '.ts',
+      '--keep-file-extension'
+    ])
+    await wait(150)
+
+    assert.ok(
+      spy.mock.calls[1].arguments[1].startsWith(
+        'Successfully copied and updated 1 typescript declaration file'
+      )
+    )
+    assert.ok(existsSync(resolve(dist, 'cjs/file.d.ts')))
+  })
+
+  it('can copy for non-compilable files', async (t) => {
+    const { babelDualPackage } = await import('../src/index.js')
+    const spy = t.mock.method(global.console, 'log')
+
+    await babelDualPackage(['test/__fixtures__/copy', '--copy-files'])
+    await wait(150)
+
+    assert.ok(spy.mock.calls[0].arguments[1].startsWith('Successfully compiled 1 file'))
+    assert.ok(existsSync(resolve(dist, 'file.html')))
+    assert.ok(existsSync(resolve(dist, 'dir', 'file.json')))
+  })
 })


### PR DESCRIPTION
* Switch from node `lstat` to `stat`.
* Add support for `--copy-files` option.
* Ensure directories are created correctly when moving TypeScript declaration files over to the `--cjs-dir-name`.