### PR TITLE
refactor: stop forcing .d.cts extension in cjs build.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babel-dual-package",
-      "version": "1.0.0-rc.4",
+      "version": "1.0.0-rc.5",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "CLI for building a dual ESM and CJS package with Babel.",
   "type": "module",
   "main": "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -173,11 +173,9 @@ const babelDualPackage = async (moduleArgs) => {
             // Restore extension if not using extended extensions
             const esmOut = esmExt || esm
             const cjsOut = cjsExt || cjs
-            // Force .cjs files to use .d.cts declarations
-            const repl = cjsOut === '.cjs' ? '.d.cts' : '$1'
 
             outEsm = outEsm.replace(dtsRegex, `${esm.replace(esmOut, '')}$1`)
-            outCjs = outCjs.replace(dtsRegex, `${cjs.replace(cjsOut, '')}${repl}`)
+            outCjs = outCjs.replace(dtsRegex, `${cjs.replace(cjsOut, '')}$1`)
           }
 
           await mkdir(dirname(outCjs), { recursive: true })

--- a/test/index.js
+++ b/test/index.js
@@ -208,10 +208,10 @@ describe('babel-dual-package', () => {
         'Successfully copied and updated 4 typescript declaration files'
       )
     )
-    assert.ok(existsSync(resolve(dist, 'cjs/file.d.cts')))
+    assert.ok(existsSync(resolve(dist, 'cjs/file.d.ts')))
   })
 
-  it('allows declaration files to have .d.ts extension in cjs dir', async (t) => {
+  it('removes stranded declaration files based on --out-file-extension', async (t) => {
     const { babelDualPackage } = await import('../src/index.js')
     const spy = t.mock.method(global.console, 'log')
 


### PR DESCRIPTION
BREAKING CHANGE:

* Stops forcing a `.d.cts` extension for declaration files in the CJS build, when the requested `--out-file-extension` ends with `.cjs`.


This one I'm not sure about and need to do some more testing with some proofs of concept.

The forcing of the `.d.cts` extension was put into place based on reading the following document (specifically, the penultimate paragraph: https://www.typescriptlang.org/docs/handbook/esm-node.html

> It’s important to note that the CommonJS entrypoint and the ES module entrypoint each needs its own declaration file, even if the contents are the same between them. Every declaration file is interpreted either as a CommonJS module or as an ES module, based on its file extension and the `"type"` field of the `package.json`, and this detected module kind must match the module kind that Node will detect for the corresponding JavaScript file for type checking to be correct. **Attempting to use a single `.d.ts` file to type both an ES module entrypoint and a CommonJS entrypoint will cause TypeScript to think only one of those entrypoints exists, causing compiler errors for users of the package**. 

That's a lot of verbiage to chew on, and I need to actually sit down and run some code against this to clarify the meaning of the words. For now, my gut says I **should not** merge this.