### PR TITLE
feat: --no-comments.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v2.1.0
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
+          tag: ${{ contains(github.ref, '-') && 'next' || 'latest' }}

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Options:
 --out-file-extension [extmap] 	 Use a specific extension for esm/cjs files. [esm:.js,cjs:.cjs]
 --keep-file-extension 		 Preserve the file extensions of the input files.
 --no-cjs-dir 			 Do not create a subdirectory for the CJS build in --out-dir.
+--no-comments 			 Remove comments from generated code.
 --source-maps 			 Generate an external source map.
 --minified  			 Save as many bytes when printing (false by default).
 --copy-files 			 When compiling a directory copy over non-compilable files.

--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ await import(
     JSON.stringify({
       '--out-dir': 'dist',
       '--no-cjs-dir': '',
+      '--no-comments': '',
       files: ['src/*.js']
     })
   )}`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,12 @@ export default [
     ignores: ['**/build.js'],
     rules: {
       'no-console': 'error',
+      'no-unused-vars': [
+        'error',
+        {
+          ignoreRestSiblings: true
+        }
+      ],
       'n/shebang': [
         'error',
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babel-dual-package",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.22.8",
-        "@babel/parser": "^7.22.7",
         "@babel/preset-env": "^7.22.7",
         "@babel/preset-react": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
@@ -484,9 +483,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-dual-package",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI for building a dual ESM and CJS package with Babel.",
   "type": "module",
   "main": "dist",
@@ -30,7 +30,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.22.8",
-    "@babel/parser": "^7.22.7",
     "@babel/preset-env": "^7.22.7",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",

--- a/src/index.js
+++ b/src/index.js
@@ -28,15 +28,25 @@ const babelDualPackage = async (moduleArgs) => {
 
   if (ctx) {
     const { args, babelProjectConfig } = ctx
-    const { targets, plugins, presets } = babelProjectConfig.options
+    const {
+      targets,
+      plugins,
+      presets,
+      babelrc: unused,
+      ...options
+    } = babelProjectConfig.options
     const outDir = resolve(relative(cwd(), args.values['out-dir']))
     const cjsOutDir = join(outDir, args.values['cjs-dir-name'])
     const keepFileExtension = args.values['keep-file-extension']
     const outFileExtension = args.values['out-file-extension']
     const noCjsDir = args.values['no-cjs-dir']
-    const sourceMaps = args.values['source-maps']
+    const minified = args.values.minified || (options.minified ?? false)
+    const noComments =
+      args.values['no-comments'] ||
+      (Object.hasOwn(options, 'comments') ? !options.comments : false)
+    const sourceMaps = args.values['source-maps'] || (options.sourceMaps ?? false)
     const copyFiles = args.values['copy-files']
-    const { minified, extensions } = args.values
+    const { extensions } = args.values
 
     if (!presets.length) {
       addDefaultPresets(presets, extensions)
@@ -52,6 +62,7 @@ const babelDualPackage = async (moduleArgs) => {
     const startTime = performance.now()
     const build = async (filename, positional) => {
       const { code, map } = await transform(filename, {
+        ...options,
         targets,
         presets,
         plugins,
@@ -60,6 +71,7 @@ const babelDualPackage = async (moduleArgs) => {
         sourceMaps,
         ast: false,
         sourceType: 'module',
+        comments: !noComments,
         // Custom options
         esmPresets,
         esmPlugins,

--- a/src/init.js
+++ b/src/init.js
@@ -75,6 +75,10 @@ const init = async (moduleArgs, onError = () => {}) => {
           type: 'boolean',
           default: false
         },
+        'no-comments': {
+          type: 'boolean',
+          default: false
+        },
         'keep-file-extension': {
           type: 'boolean',
           default: false
@@ -156,6 +160,7 @@ const init = async (moduleArgs, onError = () => {}) => {
     logHelp(
       '--no-cjs-dir \t\t\t Do not create a subdirectory for the CJS build in --out-dir.'
     )
+    logHelp('--no-comments \t\t\t Remove comments from generated code.')
     logHelp('--source-maps \t\t\t Generate an external source map.')
     logHelp('--minified  \t\t\t Save as many bytes when printing (false by default).')
     logHelp(

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs'
 import { rm, mkdir, cp, rename } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { execSync } from 'node:child_process'
 
 /* eslint-disable no-undef */
 const __filename = fileURLToPath(import.meta.url)
@@ -278,5 +279,11 @@ describe('babel-dual-package', () => {
     assert.ok(!existsSync(resolve(dist, 'cjs', 'dir', 'test.js')))
     assert.ok(!existsSync(resolve(dist, '.babelrc.json')))
     assert.ok(!existsSync(resolve(dist, 'ignored.mjs')))
+  })
+
+  it('works as a cli script', async () => {
+    const resp = execSync('./src/index.js --help', { cwd: resolve(__dirname, '..') })
+
+    assert.ok(resp.toString().indexOf('Options:') > -1)
   })
 })


### PR DESCRIPTION
* Support `--no-comments` as CLI option.
* Correctly pass the other options from a Babel config file through the programmatic API.
* Remove `@babel/parser` and use `parseAsync` from `@babel/core`.
* Set dist tag on publish derived from the release tag.